### PR TITLE
Bug fix: return correct lint type for class definition checks

### DIFF
--- a/nbcelltests/lint.py
+++ b/nbcelltests/lint.py
@@ -53,7 +53,7 @@ def lint_class_definitions(classes, max_class_definitions=-1):
     if max_class_definitions < 0:
         return [], True
     passed = classes <= max_class_definitions
-    return [LintMessage(-1, 'Checking classes per notebook (max={max_}; actual={actual})'.format(max_=max_class_definitions, actual=classes), LintType.FUNCTION_DEFINITIONS, passed)], passed
+    return [LintMessage(-1, 'Checking classes per notebook (max={max_}; actual={actual})'.format(max_=max_class_definitions, actual=classes), LintType.CLASS_DEFINITIONS, passed)], passed
 
 
 # TODO: I think this isn't lint and should be removed.

--- a/nbcelltests/tests/test_lint.py
+++ b/nbcelltests/tests/test_lint.py
@@ -5,18 +5,22 @@
 # This file is part of the nbcelltests library, distributed under the terms of
 # the Apache License 2.0.  The full license can be found in the LICENSE file.
 #
+from collections import namedtuple
 import os
 import pytest
 
 from nbcelltests.lint import lint_lines_per_cell, lint_cells_per_notebook, lint_function_definitions, lint_class_definitions, lint_cell_coverage, lint_kernelspec, lint_magics, run
+from nbcelltests.define import LintType
+
+LR = namedtuple("lint_result", ['passed', 'type'])
 
 # note that list comparison with = in this file assumes pytest
 
 
 @pytest.mark.parametrize(
     "max_lines_per_cell, cell_lines, expected_ret, expected_pass", [
-        (3, [0, 1, 2, 3, 4], [True, True, True, True, False], False),
-        (3, [0, 1, 2, 3], [True, True, True, True], True),
+        (3, [0, 1, 2, 3, 4], [LR(x, LintType.LINES_PER_CELL) for x in [True, True, True, True, False]], False),
+        (3, [0, 1, 2, 3], [LR(x, LintType.LINES_PER_CELL) for x in [True, True, True, True]], True),
         (-1, [0, 1], [], True),
     ]
 )
@@ -27,10 +31,10 @@ def test_lines_per_cell(max_lines_per_cell, cell_lines, expected_ret, expected_p
 
 @pytest.mark.parametrize(
     "max_cells_per_notebook, cell_count, expected_ret, expected_pass", [
-        (5, 10, [False], False),
-        (5, 3, [True], True),
-        (0, 10, [False], False),
-        (10, 0, [True], True),
+        (5, 10, [LR(False, LintType.CELLS_PER_NOTEBOOK)], False),
+        (5, 3, [LR(True, LintType.CELLS_PER_NOTEBOOK)], True),
+        (0, 10, [LR(False, LintType.CELLS_PER_NOTEBOOK)], False),
+        (10, 0, [LR(True, LintType.CELLS_PER_NOTEBOOK)], True),
         (-1, 10, [], True)
     ]
 )
@@ -41,10 +45,10 @@ def test_cells_per_notebook(max_cells_per_notebook, cell_count, expected_ret, ex
 
 @pytest.mark.parametrize(
     "max_function_definitions, functions, expected_ret, expected_pass", [
-        (5, 10, [False], False),
-        (5, 3, [True], True),
-        (0, 10, [False], False),
-        (10, 0, [True], True),
+        (5, 10, [LR(False, LintType.FUNCTION_DEFINITIONS)], False),
+        (5, 3, [LR(True, LintType.FUNCTION_DEFINITIONS)], True),
+        (0, 10, [LR(False, LintType.FUNCTION_DEFINITIONS)], False),
+        (10, 0, [LR(True, LintType.FUNCTION_DEFINITIONS)], True),
         (-1, 10, [], True)
     ]
 )
@@ -55,10 +59,10 @@ def test_lint_function_definitions(max_function_definitions, functions, expected
 
 @pytest.mark.parametrize(
     "max_class_definitions, classes, expected_ret, expected_pass", [
-        (5, 10, [False], False),
-        (5, 3, [True], True),
-        (0, 10, [False], False),
-        (10, 0, [True], True),
+        (5, 10, [LR(False, LintType.CLASS_DEFINITIONS)], False),
+        (5, 3, [LR(True, LintType.CLASS_DEFINITIONS)], True),
+        (0, 10, [LR(False, LintType.CLASS_DEFINITIONS)], False),
+        (10, 0, [LR(True, LintType.CLASS_DEFINITIONS)], True),
         (-1, 10, [], True)
     ]
 )
@@ -69,9 +73,9 @@ def test_lint_class_definitions(max_class_definitions, classes, expected_ret, ex
 
 @pytest.mark.parametrize(
     "test_count, cell_count, min_cell_coverage, expected_ret, expected_pass", [
-        (0, 10, 50, [False], False),
-        (5, 10, 50, [True], True),
-        (0, 10, 0, [True], True),
+        (0, 10, 50, [LR(False, LintType.CELL_COVERAGE)], False),
+        (5, 10, 50, [LR(True, LintType.CELL_COVERAGE)], True),
+        (0, 10, 0, [LR(True, LintType.CELL_COVERAGE)], True),
         (0, 10, -1, [], True),
         (0, 0, 0, [], True)
     ]
@@ -84,10 +88,10 @@ def test_cell_coverage(test_count, cell_count, min_cell_coverage, expected_ret, 
 @pytest.mark.parametrize(
     "kernelspec_requirements, kernelspec, expected_ret, expected_pass", [
         ({'name': 'python3'}, {'name': 'python3',
-                               'display_name': 'Python 3'}, [True], True),
-        ({'name': 'python3'}, {'name': 'python2'}, [False], False),
+                               'display_name': 'Python 3'}, [LR(True, LintType.KERNELSPEC)], True),
+        ({'name': 'python3'}, {'name': 'python2'}, [LR(False, LintType.KERNELSPEC)], False),
         ({}, {'name': 'python3',
-              'display_name': 'Python 3'}, [True], True),
+              'display_name': 'Python 3'}, [LR(True, LintType.KERNELSPEC)], True),
         (False, {}, [], True),
         (False, {'something': 'else'}, [], True),
     ]
@@ -103,13 +107,13 @@ def test_kernelspec(kernelspec_requirements, kernelspec, expected_ret, expected_
         (None, None, [], [], True),
         (None, None, ['anything'], [], True),
         # empty whitelist: no magics allowed
-        ([], None, ['anything'], [False], False),
+        ([], None, ['anything'], [LR(False, LintType.MAGICS)], False),
         # only whitelisted
-        (['ok1', 'ok2'], None, ['ok1'], [True], True),
-        (['ok1', 'ok2'], None, ['notok'], [False], False),
+        (['ok1', 'ok2'], None, ['ok1'], [LR(True, LintType.MAGICS)], True),
+        (['ok1', 'ok2'], None, ['notok'], [LR(False, LintType.MAGICS)], False),
         # no blacklisted
-        (None, ['notok'], ['ok'], [True], True),
-        (None, ['notok'], ['notok'], [False], False),
+        (None, ['notok'], ['ok'], [LR(True, LintType.MAGICS)], True),
+        (None, ['notok'], ['notok'], [LR(False, LintType.MAGICS)], False),
     ]
 )
 def test_magics(magics_whitelist, magics_blacklist, magics, expected_ret, expected_pass):
@@ -140,13 +144,13 @@ def test_magics_lists_sanity():
         # one rule, pass
         ({'lines_per_cell': -1}, [], True),
         # one rule, fail
-        ({'lines_per_cell': 1}, [False, True, True, True, False, False], False),
+        ({'lines_per_cell': 1}, [LR(x, LintType.LINES_PER_CELL) for x in [False, True, True, True, False, False]], False),
         # multiple rules, combo fail
         ({'lines_per_cell': 5,
-          'cells_per_notebook': 1}, [True, True, True, True, True, True, False], False),
+          'cells_per_notebook': 1}, [LR(True, LintType.LINES_PER_CELL)] * 6 + [LR(False, LintType.CELLS_PER_NOTEBOOK)], False),
         # multiple rules, combo pass
         ({'lines_per_cell': 5,
-          'cells_per_notebook': 10}, [True, True, True, True, True, True, True], True),
+          'cells_per_notebook': 10}, [LR(True, LintType.LINES_PER_CELL)] * 6 + [LR(True, LintType.CELLS_PER_NOTEBOOK)], True),
         # all the expected rules
         ({'lines_per_cell': 5,
           'cells_per_notebook': 2,
@@ -155,7 +159,7 @@ def test_magics_lists_sanity():
           'cell_coverage': 90,
           'kernelspec_requirements':
             {'name': 'python3'},
-          'magics_whitelist': ['matplotlib']}, [True, True, True, True, True, True, False, False, False, False, True, True], False)
+          'magics_whitelist': ['matplotlib']}, [LR(True, LintType.LINES_PER_CELL)] * 6 + [LR(False, LintType.CELLS_PER_NOTEBOOK)] + [LR(False, LintType.FUNCTION_DEFINITIONS)] + [LR(False, LintType.CLASS_DEFINITIONS)] + [LR(False, LintType.CELL_COVERAGE)] + [LR(True, LintType.KERNELSPEC)] + [LR(True, LintType.MAGICS)], False)
     ]
 )
 def test_run(rules, expected_ret, expected_pass):
@@ -165,5 +169,5 @@ def test_run(rules, expected_ret, expected_pass):
 
 
 def _verify(ret, passed, expected_ret, expected_pass):
-    assert [r.passed for r in ret] == expected_ret
+    assert [(r.passed, r.type) for r in ret] == [(e.passed, e.type) for e in expected_ret]
     assert passed is expected_pass


### PR DESCRIPTION
Bug fix: "class definitions" lint check was returning the "function definition" lint type.

Bug would affect anyone who was:
  * displaying the lint type ("cosmetic")
  * conditioning something on the lint type, with different conditions for function and class definition counts.

This PR also adds tests that lint type is as expected.